### PR TITLE
Calculate final position and animate to that position

### DIFF
--- a/Sources/CrownRotationToSpinningWheel/CrownVelocity.swift
+++ b/Sources/CrownRotationToSpinningWheel/CrownVelocity.swift
@@ -36,6 +36,10 @@ public class CrownVelocity {
             data.append(CrownRotationDatum(angle: lastDatum.angle, time: newDate))
         }
     }
+
+    func clearData() {
+        data = []
+    }
 }
 
 struct CrownRotationDatum {

--- a/Sources/CrownRotationToSpinningWheel/CrownVelocity.swift
+++ b/Sources/CrownRotationToSpinningWheel/CrownVelocity.swift
@@ -11,7 +11,7 @@ public class CrownVelocity {
     let memory: Double
     var data = [CrownRotationDatum]()
 
-    public init(memory: Double = 0.1) {
+    public init(memory: Double = 1) {
         self.memory = memory
     }
 
@@ -21,11 +21,20 @@ public class CrownVelocity {
 
     public func velocity(at currentTime: Date = Date()) -> Double {
         data = data.filter { abs($0.time.timeIntervalSince(currentTime)) < memory }
+        addLatestTimePoint(&data)
         guard data.count > 1 else {
             return 0.0
         }
         let vs = (1 ..< data.count).map { data[$0] - data[$0 - 1] }
         return vs.reduce(0.0, +) / Double(vs.count)
+    }
+
+    func addLatestTimePoint(_ data: inout [CrownRotationDatum], minimumTimeDifference: Double = 0.1) {
+        guard let lastDatum: CrownRotationDatum = data.last else { return }
+        let newDate = Date()
+        if newDate.timeIntervalSince1970 - lastDatum.time.timeIntervalSince1970 > minimumTimeDifference {
+            data.append(CrownRotationDatum(angle: lastDatum.angle, time: newDate))
+        }
     }
 }
 

--- a/Sources/CrownRotationToSpinningWheel/SpinningWheel.swift
+++ b/Sources/CrownRotationToSpinningWheel/SpinningWheel.swift
@@ -31,6 +31,7 @@ public class SpinningWheel: ObservableObject {
 
     func updateWheelVelocity() {
         let cv = crownVelocity.velocity()
+        print("crown velocity: \(cv)")
         if abs(cv) > minimumSignificantVelocity {
             wheelVelocity = cv
         } else {
@@ -40,17 +41,24 @@ public class SpinningWheel: ObservableObject {
 
     func updateWheelRotationAngle() {
         updateWheelVelocity()
-        wheelRotation = calculateFinalAngle(velocity: wheelVelocity)
+        print("wheel velocity: \(wheelVelocity)")
+        wheelRotation = calculateFinalAngle(initialAngle: wheelRotation, velocity: wheelVelocity)
+        print("wheel rotation angle: \(wheelRotation)")
     }
 
-    func calculateFinalAngle(velocity: Double) -> Double {
-        0.5 * (velocity - minimumSignificantVelocity) * totalTimeOfExponentialDecay(initialValue: velocity, finalValue: minimumSignificantVelocity)
+    func calculateFinalAngle(initialAngle: Double, velocity: Double) -> Double {
+        if abs(velocity) < minimumSignificantVelocity { return wheelRotation }
+        let dAngle = 0.5 * (velocity - minimumSignificantVelocity) * abs(totalTimeOfExponentialDecay(initialValue: velocity, finalValue: minimumSignificantVelocity))
+        return dAngle + initialAngle
     }
 
     func decay(wheelVelocity wv: Double, until newTimePoint: Date = Date()) -> Double {
+        if abs(wheelVelocity) < minimumSignificantVelocity { return 0 }
+
         let dTime = previousReadingTimepoint.distance(to: newTimePoint)
         let newWheelVelocity = exponentialDecay(starting: wv, after: dTime)
         previousReadingTimepoint = newTimePoint
+
         return newWheelVelocity
     }
 
@@ -59,6 +67,6 @@ public class SpinningWheel: ObservableObject {
     }
 
     func totalTimeOfExponentialDecay(initialValue: Double, finalValue: Double, decayConstant: Double = 0.1) -> Double {
-        -1.0 * (1.0 / decayConstant) * log(finalValue / initialValue)
+        -1.0 * (1.0 / decayConstant) * log(abs(finalValue) / abs(initialValue))
     }
 }

--- a/Sources/CrownRotationToSpinningWheel/SpinningWheel.swift
+++ b/Sources/CrownRotationToSpinningWheel/SpinningWheel.swift
@@ -19,44 +19,46 @@ public class SpinningWheel: ObservableObject {
     var wheelVelocity: Double = 0.0
     @Published public var wheelRotation: Double = 0.0
 
-    public init(damping: Double = 0.2, crownVelocityMemory: Double = 0.1) {
+    public init(damping: Double = 0.2, crownVelocityMemory: Double = 1) {
         self.damping = damping
         crownVelocity = CrownVelocity(memory: crownVelocityMemory)
     }
 
     public func crownInput(angle: Double, at time: Date) {
         crownVelocity.new(angle: angle, at: time)
+        updateWheelRotationAngle()
     }
 
     func updateWheelVelocity() {
         let cv = crownVelocity.velocity()
         if abs(cv) > minimumSignificantVelocity {
-            if crownAndWheelAreRotatingInTheSaveDirection(cv: cv) {
-                if abs(cv) > abs(wheelVelocity) {
-                    wheelVelocity = cv
-                }
-            } else {
-                wheelVelocity += cv
-            }
-        } else if abs(wheelVelocity) < minimumSignificantVelocity {
-            wheelVelocity = 0.0
+            wheelVelocity = cv
         } else {
-            wheelVelocity *= (1.0 - damping)
+            wheelVelocity = decay(wheelVelocity: wheelVelocity)
         }
     }
 
-    func crownAndWheelAreRotatingInTheSaveDirection(cv: Double) -> Bool {
-        return cv / cv == wheelVelocity / wheelVelocity
-    }
-
-    func updateWheelRotation(after timeInterval: Double) {
-        wheelRotation += timeInterval * wheelVelocity
-    }
-
-    public func update() {
+    func updateWheelRotationAngle() {
         updateWheelVelocity()
-        let newReadingTimepoint = Date()
-        updateWheelRotation(after: newReadingTimepoint.distance(to: previousReadingTimepoint))
-        previousReadingTimepoint = newReadingTimepoint
+        wheelRotation = calculateFinalAngle(velocity: wheelVelocity)
+    }
+
+    func calculateFinalAngle(velocity: Double) -> Double {
+        0.5 * (velocity - minimumSignificantVelocity) * totalTimeOfExponentialDecay(initialValue: velocity, finalValue: minimumSignificantVelocity)
+    }
+
+    func decay(wheelVelocity wv: Double, until newTimePoint: Date = Date()) -> Double {
+        let dTime = previousReadingTimepoint.distance(to: newTimePoint)
+        let newWheelVelocity = exponentialDecay(starting: wv, after: dTime)
+        previousReadingTimepoint = newTimePoint
+        return newWheelVelocity
+    }
+
+    func exponentialDecay(starting from: Double, after time: TimeInterval, decayConstant: Double = 0.1) -> Double {
+        from * exp(-1 * decayConstant * time)
+    }
+
+    func totalTimeOfExponentialDecay(initialValue: Double, finalValue: Double, decayConstant: Double = 0.1) -> Double {
+        -1.0 * (1.0 / decayConstant) * log(finalValue / initialValue)
     }
 }

--- a/Tests/CrownRotationToSpinningWheelTests/CrownVelocityTests.swift
+++ b/Tests/CrownRotationToSpinningWheelTests/CrownVelocityTests.swift
@@ -14,7 +14,7 @@ final class CrownVelocityTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        crownVelocity = CrownVelocity(memory: 10.0)
+        crownVelocity = CrownVelocity(memory: 100_000)
     }
 
     override func tearDown() {
@@ -47,6 +47,40 @@ final class CrownVelocityTests: XCTestCase {
         let expectedVelocity = 0.1
         XCTAssertTrue(areClose(velocity, expectedVelocity),
                       "\(velocity) and \(expectedVelocity) are not equal.")
+    }
+
+    func testAdditionOfNewDataPointAfterSufficientTime() {
+        // Given
+        let mockVelocityData = mockCrownVelocityData(n: 10, timeInterval: 0.1, startingDate: Date().advanced(by: -200))
+        mockVelocityData.applyData(to: crownVelocity)
+
+        // When
+        let initialCount = crownVelocity.data.count
+        crownVelocity.addLatestTimePoint(&crownVelocity.data)
+
+        // Then
+        XCTAssertTrue(crownVelocity.data.count == initialCount + 1)
+    }
+
+    func testSlowerVelocityAfterTimeWithNoNewData() {
+        // Given (1)
+        let mockVelocityData1 = mockCrownVelocityData(n: 10, timeInterval: 0.1, startingDate: Date().advanced(by: -200))
+        mockVelocityData1.applyData(to: crownVelocity)
+
+        // When (1)
+        let velocity1 = crownVelocity.velocity()
+
+        crownVelocity.clearData()
+
+        // Given (2)
+        let mockVelocityData2 = mockCrownVelocityData(n: 10, timeInterval: 0.1, startingDate: Date())
+        mockVelocityData2.applyData(to: crownVelocity)
+
+        // When (2)
+        let velocity2 = crownVelocity.velocity()
+
+        // Then
+        XCTAssertGreaterThan(velocity2, velocity1)
     }
 
     func areClose(_ a: Double, _ b: Double, error: Double = 0.01) -> Bool {

--- a/Tests/CrownRotationToSpinningWheelTests/SpinningWheelTests.swift
+++ b/Tests/CrownRotationToSpinningWheelTests/SpinningWheelTests.swift
@@ -13,7 +13,7 @@ final class SpinningWheelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        spinningWheel = SpinningWheel(damping: 0.1, crownVelocityMemory: 10)
+        spinningWheel = SpinningWheel(damping: 0.1, crownVelocityMemory: 20)
     }
 
     override func tearDown() {
@@ -21,31 +21,41 @@ final class SpinningWheelTests: XCTestCase {
         super.tearDown()
     }
 
+    func testExponentialDecayCalculation() {
+        // Given
+        let start = 5000.0
+        let decayConstant = 0.5
+        let halfLife = log(2.0) / decayConstant
+
+        // When
+        let final = spinningWheel.exponentialDecay(starting: start, after: halfLife, decayConstant: decayConstant)
+
+        // Then
+        XCTAssertEqual(final, start / 2)
+    }
+
+    func testTotalTimeOfExponentialDecay() {
+        // Given
+        let start = 1000.0
+        let final = start / 2.0
+        let decayConstant = 0.5
+
+        // When
+        let duration = spinningWheel.totalTimeOfExponentialDecay(initialValue: start, finalValue: final, decayConstant: decayConstant)
+
+        // Then
+        XCTAssertEqual(duration, log(2.0) / decayConstant)
+    }
+
     func testWheelVelocityIncrease() {
         // Given
-        let mockVelocityData = mockCrownVelocityData(n: 10, timeInterval: 1.0)
+        let mockData = mockCrownVelocityData(n: 10, timeInterval: 1)
 
         // When
-        mockVelocityData.applyData(to: spinningWheel)
-        spinningWheel.updateWheelVelocity()
+        mockData.applyData(to: spinningWheel)
 
         // Then
-        XCTAssertEqual(spinningWheel.crownVelocity.velocity(), spinningWheel.wheelVelocity)
-
-        // When
-        spinningWheel.updateWheelVelocity()
-
-        // Then
-        XCTAssertEqual(spinningWheel.crownVelocity.velocity(), spinningWheel.wheelVelocity)
-
-        // When
-        let originalWheelVelocity = spinningWheel.wheelVelocity
-        spinningWheel.crownVelocity.data = [] // Crown velocty -> 0
-        spinningWheel.updateWheelVelocity()
-
-        // Then
-        XCTAssertEqual(spinningWheel.crownVelocity.velocity(), 0.0)
-        XCTAssertEqual(spinningWheel.wheelVelocity, originalWheelVelocity * (1 - spinningWheel.damping))
+        XCTAssertTrue(spinningWheel.wheelRotation > 0)
     }
 
     func testReverseCrownVelocity() {


### PR DESCRIPTION
A complete change in the methodology of the spinning wheel calculations. Instead of updating the angle of the wheel repeatedly, the final rotation angle is calculated every time new crown rotation data is added. This final position is an estimate of an exponential decay function. The final wheel position is accessible as a publisher, so the wheel rotation can be assigned to monitor that value and animation is used to interpolate between the current and final rotation.